### PR TITLE
Bugs related to 'optional'

### DIFF
--- a/paper-step.html
+++ b/paper-step.html
@@ -34,7 +34,8 @@ Missing Doc
       }
       #slideshowViewport {
         position: absolute;
-        bottom: 84px;
+        top: 127px;
+        bottom: 70px;
         left: 0;
         right: 0;
         overflow: hidden;

--- a/paper-step.html
+++ b/paper-step.html
@@ -34,7 +34,6 @@ Missing Doc
       }
       #slideshowViewport {
         position: absolute;
-        top: 127px;
         bottom: 70px;
         left: 0;
         right: 0;

--- a/paper-step.html
+++ b/paper-step.html
@@ -132,7 +132,8 @@ Missing Doc
          */
         optional: {
           type: Boolean,
-          value: false
+          value: false,
+          observer: 'optionalChanged'
         },
         /**
          * Missing Doc
@@ -287,12 +288,20 @@ Missing Doc
         this.toggleClass('neon-animating', false);
       },
 
-      _updateSlideshowViewportTop: function(optional, _alternativeLabel, vertical) {
-        if (!vertical) {
-          this.async(function() {
+      _updateSlideshowViewportTop: function() {
+        // fix issue where this function is called before the element is finished initializing
+        if (this.vertical === undefined) {
+          this.async(this._updateSlideshowViewportTop, 200);
+          return;
+        }
+        if (!this.vertical) {
+          var setTop = function() {
             this.$$('#slideshowViewport').style.top = this.clientHeight+'px';
             this.fire('step-horizontal-label-resize');
-          })
+          };
+          this.async(setTop);
+          // fix bug where top is incorrect if optional is set
+          this.async(setTop, 200);
         }
       },
 
@@ -327,6 +336,10 @@ Missing Doc
       _computeSelectable: function(linear, saved, editable, previousSaved) {
         // TODO: factorize the expression
         return (!linear || previousSaved) && (!saved || editable) || (editable && saved);
+      },
+
+      optionalChanged: function() {
+        this.fire('optional-changed');
       }
 
     });

--- a/paper-stepper.html
+++ b/paper-stepper.html
@@ -252,7 +252,8 @@ Missing Doc
         'paper-step-saved': '_stepSaved',
         'transitionend': '_transitionEnd',
         'step-horizontal-label-resize': '_updateStepperClosedMaxHeight',
-        'iron-resize': '_resizeHandler'
+        'iron-resize': '_resizeHandler',
+        'optional-changed': '_updateSlideshowViewportTops',
       },
 
       observers: [
@@ -557,6 +558,12 @@ Missing Doc
           this.vertical = !(this.clientWidth > verticalResponsiveWidth);
         }
       },
+
+      _updateSlideshowViewportTops: function() {
+        this.items.map(function(step) {
+          step._updateSlideshowViewportTop();
+        });
+      }
 
     });
 


### PR DESCRIPTION
There were a couple of rendering bugs if optional is set or changed.

Bug 1: Optional is an attribute for paper-step, but if optional is set, the size of the paper-stepper changes in height if alternative-label is true. This causes the top for #slideshowViewport to be incorrect for all the paper-steps before the one that changes the height of the paper-stepper.

Bug 2: If a paper-step changes to optional after all the paper-steps are rendered, the #slideshowViewport top is only updated for the one paper-step.

<img width="648" alt="screen shot 2016-09-12 at 12 12 00 pm" src="https://cloud.githubusercontent.com/assets/6618430/18449767/1fdace80-78f6-11e6-985a-b01d000eab62.png">
