### PR TITLE
make sure #slideshowViewport is properly aligned

### DIFF
--- a/paper-stepper.html
+++ b/paper-stepper.html
@@ -714,6 +714,11 @@ Custom property | Description | Default
       _resizeHandler: function() {
         this.debounce('paper-stepper-responsive-check', function() {
           this._responsiveCheck();
+          if(!this.vertical) {
+            this.items.forEach(function(step) {
+               step._updateSlideshowViewportTop();
+            });
+          }
         }, this.responsiveCheckFrequence);
       },
 


### PR DESCRIPTION
When a stepper is not visible on its first render (e.g. rendered in an inactive paper-tab), the `top` position of `#slideshowViewport` is `0`. The content of the slideshow hence overlap with stepper labels. 

This PR makes sure we recalculate slideshowViewport' top position on resize.
